### PR TITLE
Fix pointer error

### DIFF
--- a/ps5-wake.c
+++ b/ps5-wake.c
@@ -86,7 +86,7 @@ static int ddp_parse(char *buffer, struct ddp_reply *reply)
             token[2] == 'T' && token[3] == 'P') {
             for (p = token + 8; *p == ' '; p++);
             for (c = p; isdigit(*p); p++);
-            p = '\0'; reply->code = (short)atoi(c);
+            *p = '\0'; reply->code = (short)atoi(c);
             continue;
         }
 


### PR DESCRIPTION
This fixes the following warning:
```
gcc -O2 -g -pipe -Wall -std=gnu99 ps5-wake.c sha1.c -o ps5-wake
ps5-wake.c:89:17: warning: expression which evaluates to zero treated as a null pointer constant of type
      'char *' [-Wnon-literal-null-conversion]
            p = '\0'; reply->code = (short)atoi(c);
                ^~~~
1 warning generated.
```